### PR TITLE
Fix camera model type and size form layout

### DIFF
--- a/app/assets/stylesheets/cameras.scss
+++ b/app/assets/stylesheets/cameras.scss
@@ -64,7 +64,7 @@
   margin-bottom: 20px;
 }
 .size-weight-layout{
-  width: 50px;
+  width: 100px;
 }
 .camera-box{
   border: solid 1px;

--- a/app/controllers/cameras_controller.rb
+++ b/app/controllers/cameras_controller.rb
@@ -13,7 +13,7 @@ class CamerasController < ApplicationController
 
   def create
     @camera = Camera.new(camera_params)
-    @camera.size = params[:camera][:width] + '*' + params[:camera][:height] + '*' + params[:camera][:depth]
+    @camera.size = params[:camera][:width] + '×' + params[:camera][:height] + '×' + params[:camera][:depth]
     if @camera.save
       redirect_to root_path
     else

--- a/app/models/camera.rb
+++ b/app/models/camera.rb
@@ -15,7 +15,7 @@ class Camera < ApplicationRecord
   validates :camera_type, presence: true
   validates :audio, presence: true
   validates :size, presence: true
-  validates :weight, presence: true, :numericality => { :less_than => 100 }
+  validates :weight, presence: true, :numericality => { :less_than => 100000 }
 
   enum resolution:{"4K": 0, "FullHD": 1, "HD": 2, "VGA": 3}
   enum camera_type:{"ボックス型": 0, "ドーム型": 1, "バレット型": 2, "非破壊型": 3, "魚眼カメラ": 4, "PTZカメラ": 5}

--- a/app/views/cameras/new.html.erb
+++ b/app/views/cameras/new.html.erb
@@ -1,7 +1,7 @@
-<div class="row register-form">
+<div class="row ">
     <div class="col-md-8 offset-md-2">
       <h1>カメラ登録</h1>
-        <%= form_for @camera, class:"custom-form" do |f| %>
+        <%= form_for @camera do |f| %>
           <%= f.label "カメラ名" %>
           <%= f.text_field :camera_name, class: 'form-control', placeholder:'カメラ名を入力' %>
           <div class="label-layout">
@@ -21,18 +21,14 @@
             <%= f.select :audio, Camera.audios.keys.to_a, {}, class: 'form_control' %>
           </div>
           <div class="label-layout">
-            <%= f.label "寸法" %>
-            <%= f.text_field :width, class: 'form-control size-weight-layout', placeholder:'幅(mm)' %>
-            <%= f.text_field :height, class: 'form-control', placeholder:'高さ(mm)' %>
-            <%= f.text_field :depth, class: 'form-control', placeholder:'奥行き(mm)' %>
+            <%= f.label "寸法" %><br>
+            <%= f.text_field :width, class: 'size-weight-layout mb-2', placeholder:'幅(mm)' %>
+            <%= f.text_field :height, class: 'size-weight-layout mb-2 ', placeholder:'高さ(mm)' %>
+            <%= f.text_field :depth, class: 'size-weight-layout mb-2', placeholder:'奥行き(mm)' %>
           </div>
           <div class="label-layout">
             <%= f.label "重量" %>
-            <%= f.text_field :weight, class: 'form-control', placeholder:'重量を入力(kg)' %>
-          </div>
-          <div class="label-layout">
-            <%= f.label "説明文" %>
-            <%= f.text_field :description, class: 'form-control description-layout', style:'height:300px;' %>
+            <%= f.text_field :weight, class: 'form-control', placeholder:'重量を入力(g)' %>
           </div>
           <div class="label-layout">
             <%= f.fields_for :camera_images do |c| %>

--- a/db/migrate/20190128073417_change_columns_weight_to_camera.rb
+++ b/db/migrate/20190128073417_change_columns_weight_to_camera.rb
@@ -1,0 +1,5 @@
+class ChangeColumnsWeightToCamera < ActiveRecord::Migration[5.2]
+  def change
+    change_column :cameras, :weight, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_28_052111) do
+ActiveRecord::Schema.define(version: 2019_01_28_073417) do
 
   create_table "admins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "mail"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2019_01_28_052111) do
     t.integer "camera_type"
     t.integer "audio"
     t.string "size"
-    t.integer "weight"
+    t.float "weight"
     t.bigint "manufacturer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
# What
weightのバリデーションの数値を引き上げ
weightの型をintegerからfloatに変更
sizeの結合文字の変更
説明文の入力フォームを削除
weightフォームのレイアウトを横並びに修正

# Why
UI/UXの向上
サービス必須機能のため