### PR TITLE
[Fix] 各index_pageのcamera_nameをtruncateで表示を制限

### DIFF
--- a/app/views/admins/camera_index.html.erb
+++ b/app/views/admins/camera_index.html.erb
@@ -21,7 +21,7 @@
                 <%= image_tag('no_image.png', style:"width: 40px; height: 40px") %>
               <% end %>
             </td>
-            <td><%= camera.camera_name %></td>
+            <td><%= camera.camera_name.truncate(15) %></td>
             <td><%= @manufacturer_name %></td>
             <td><%= camera.camera_type %></td>
             <td><%= simple_time(camera.created_at) %></td>

--- a/app/views/cameras/camera_type_groups_index.html.erb
+++ b/app/views/cameras/camera_type_groups_index.html.erb
@@ -54,7 +54,7 @@
                 <%= @manufacturer_name %>
               </span><br>
               <span class="camera_name">
-                <%= camera.camera_name %>
+                <%= camera.camera_name.truncate(15) %>
               </span><br>
               <span class="camera_type">
                 <%= camera.camera_type %>

--- a/app/views/cameras/impression_ranking.html.erb
+++ b/app/views/cameras/impression_ranking.html.erb
@@ -60,7 +60,7 @@
                 <%= @manufacturer_name %>
               </span><br>
               <span class="camera_name">
-                <%= camera.camera_name %>
+                <%= camera.camera_name.truncate(15) %>
               </span><br>
               <span class="camera_type">
                 <%= camera.camera_type %>

--- a/app/views/cameras/index.html.erb
+++ b/app/views/cameras/index.html.erb
@@ -54,7 +54,7 @@
                 <%= @manufacturer_name %>
               </span><br>
               <span class="camera_name">
-                <%= camera.camera_name %>
+                <%= camera.camera_name.truncate(15) %>
               </span><br>
               <span class="camera_type">
                 <%= camera.camera_type %>

--- a/app/views/cameras/manufacturer_groups_index.html.erb
+++ b/app/views/cameras/manufacturer_groups_index.html.erb
@@ -55,7 +55,7 @@
                 <%= @manufacturer_name %>
               </span><br>
               <span class="camera_name">
-                <%= camera.camera_name %>
+                <%= camera.camera_name.truncate(15) %>
               </span><br>
               <span class="camera_type">
                 <%= camera.camera_type %>

--- a/app/views/cameras/resolution_groups_index.html.erb
+++ b/app/views/cameras/resolution_groups_index.html.erb
@@ -54,7 +54,7 @@
                 <%= @manufacturer_name %>
               </span><br>
               <span class="camera_name">
-                <%= camera.camera_name %>
+                <%= camera.camera_name.truncate(15) %>
               </span><br>
               <span class="camera_type">
                 <%= camera.camera_type %>

--- a/app/views/cameras/search_result.html.erb
+++ b/app/views/cameras/search_result.html.erb
@@ -54,7 +54,7 @@
                 <%= @manufacturer_name %>
               </span><br>
               <span class="camera_name">
-                <%= camera.camera_name %>
+                <%= camera.camera_name.truncate(15) %>
               </span><br>
               <span class="camera_type">
                 <%= camera.camera_type %>


### PR DESCRIPTION
# What
各index pageのcamera_nameにtruncateを当てる

# Why
UI向上のため