### PR TITLE
[Fix] カメラ削除のモーダルで参照idが不一致になる不具合を修正

### DIFF
--- a/app/views/admins/camera_index.html.erb
+++ b/app/views/admins/camera_index.html.erb
@@ -26,7 +26,7 @@
             <td><%= camera.camera_type %></td>
             <td><%= simple_time(camera.created_at) %></td>
             <td>
-              <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#deleteConfirmation">削除</button>
+              <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#deleteConfirmation_<%= camera.id  %>" >削除</button>
               <%= render partial: 'layouts/camera_delete_modal', locals: { camera: camera } %>
             </td>
         </tr>

--- a/app/views/layouts/_camera_delete_modal.html.erb
+++ b/app/views/layouts/_camera_delete_modal.html.erb
@@ -1,4 +1,5 @@
-<div class="modal fade" id="deleteConfirmation">
+
+<div class="modal fade" id="deleteConfirmation_<%= camera.id  %>">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">


### PR DESCRIPTION
# What
カメラ削除のモーダルでのid不一致を修正

# Why
サービス必須機能のため